### PR TITLE
fix getting item from collection with double-colon separated key

### DIFF
--- a/src/Setting/SettingCollection.php
+++ b/src/Setting/SettingCollection.php
@@ -27,4 +27,16 @@ class SettingCollection extends EntryCollection
         }
     }
 
+    /**
+     * Get an item out of the collection, identified by $key
+     * $key might be "double colon separated", so convert that to a dot-notation the collection can work with
+     *
+     * @param string $key
+     * @param mixed $default
+     */
+    public function get($key, $default = null)
+    {
+        // convert the db keyname to a collection compatible keyname
+        return parent::get(str_replace('::', '.', $key), $default);
+    }
 }


### PR DESCRIPTION
Setting model was not being received, if fetched with a double colon notation (e. g. settings::name), since the keys are converted to dot notation (settings.name) in the constructor of the selection.

This lead to an "duplicate entry" error when trying to save settings (SettingRepository, line 179, $this->collection->get($key) returns null so the system tries to "put" the setting, which fails due to db contrains)
